### PR TITLE
courses/c02/def-templ3_4.d: Attempt to fix-and-test fib (Fibonacci).

### DIFF
--- a/courses/c02/def-templ3_4.d
+++ b/courses/c02/def-templ3_4.d
@@ -1,24 +1,26 @@
 module def_templ;
 
-import std.stdio;
-
-T getResponse(T = int)(string question)
+ulong fib(uint N)()
 {
-    writef("%s (%s): ", question, T.stringof);
-    T response;
-    readf(" %s", &response);
-
-    return response;
+    static if (N <= 1)
+        return N;
+    else
+        return fib!(N - 2)() + fib!(N - 1)();
 }
 
-int fib(int N)()
+void fibDisplay(uint N)()
 {
-    if (N == 0)
-        return 0;
-    return N + fib!(N - 1)();
+    static if (N > 0)
+        fibDisplay!(N - 1)();
+
+    import std.stdio;
+    writef("fib ! %2u () == %19u\n", N, fib!N());
 }
 
 void main(string[] args)
 {
+    fibDisplay!45();
+
     auto x = fib!(10)();
+    assert(x == 55);
 }


### PR DESCRIPTION
Test command:

```
$ cd courses/c02/ && "$(which time)" rdmd def-templ3_4.d
```

Test result (on second-and-subsequent runs):

```
fib !  0 () ==          0
fib !  1 () ==          1
fib !  2 () ==          1
fib !  3 () ==          2
fib !  4 () ==          3
fib !  5 () ==          5
fib !  6 () ==          8
fib !  7 () ==         13
fib !  8 () ==         21
fib !  9 () ==         34
fib ! 10 () ==         55
fib ! 11 () ==         89
fib ! 12 () ==        144
fib ! 13 () ==        233
fib ! 14 () ==        377
fib ! 15 () ==        610
fib ! 16 () ==        987
fib ! 17 () ==       1597
fib ! 18 () ==       2584
fib ! 19 () ==       4181
fib ! 20 () ==       6765
fib ! 21 () ==      10946
fib ! 22 () ==      17711
fib ! 23 () ==      28657
fib ! 24 () ==      46368
fib ! 25 () ==      75025
fib ! 26 () ==     121393
fib ! 27 () ==     196418
fib ! 28 () ==     317811
fib ! 29 () ==     514229
fib ! 30 () ==     832040
fib ! 31 () ==    1346269
fib ! 32 () ==    2178309
fib ! 33 () ==    3524578
fib ! 34 () ==    5702887
fib ! 35 () ==    9227465
fib ! 36 () ==   14930352
fib ! 37 () ==   24157817
fib ! 38 () ==   39088169
fib ! 39 () ==   63245986
fib ! 40 () ==  102334155
fib ! 41 () ==  165580141
fib ! 42 () ==  267914296
fib ! 43 () ==  433494437
fib ! 44 () ==  701408733
fib ! 45 () == 1134903170
0.00user 0.00system 0:15.42elapsed 0%CPU (0avgtext+0avgdata 200448maxresident)k
0inputs+0outputs (1023major+0minor)pagefaults 0swaps
```

15 seconds needed for an AMD FX-4100 3600 MHz computer (with DMD for Win32).

I wonder what the results are for other systems.  (-: